### PR TITLE
Fix error-handling consistency

### DIFF
--- a/db/article.go
+++ b/db/article.go
@@ -16,25 +16,25 @@ type Article struct {
 }
 
 // Get all data
-func GetArticles(username string) ([]Article, ErrorResponse) {
+func GetArticles(username string) ([]Article, error) {
 	var articles []Article
 
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return articles, errResp
+	db, err := gormConnect()
+	if err != nil {
+		return articles, err
 	}
 
 	defer db.Close()
 	// Get all article data by specifying empty condition as the Find argument
 	db.Order("created_at desc").Where("Username = ?", username).Find(&articles)
-	return articles, ErrorResponse{IsError: false}
+	return articles, nil
 }
 
 // Insert data
-func PostArticle(article Article) ErrorResponse {
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+func PostArticle(article Article) error {
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	defer db.Close()
@@ -45,14 +45,14 @@ func PostArticle(article Article) ErrorResponse {
 		Tags:     article.Tags,
 	})
 
-	return ErrorResponse{IsError: false}
+	return nil
 }
 
 // Update DB
-func UpdateArticle(articleID int, updateArticle Article) ErrorResponse {
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+func UpdateArticle(articleID int, updateArticle Article) error {
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	// Delete old tags associated to this article
@@ -63,8 +63,7 @@ func UpdateArticle(articleID int, updateArticle Article) ErrorResponse {
 	var article Article
 	db.First(&article, articleID)
 	if !isUserMatched(article.Username, updateArticle.Username) {
-		return ErrorResponse{
-			IsError: true,
+		return &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "User is not matched",
 		}
@@ -74,27 +73,25 @@ func UpdateArticle(articleID int, updateArticle Article) ErrorResponse {
 	db.Save(&article)
 	db.Close()
 
-	return ErrorResponse{IsError: false}
+	return nil
 }
 
 // Delete a article
-func DeleteArticle(id int, username string) ErrorResponse {
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+func DeleteArticle(id int, username string) error {
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	var article Article
 	if err := db.First(&article, id).Error; err != nil {
-		return ErrorResponse{
-			IsError: true,
+		return &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "The article is not existed.",
 		}
 	}
 	if !isUserMatched(article.Username, username) {
-		return ErrorResponse{
-			IsError: true,
+		return &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "User is not matched",
 		}
@@ -103,7 +100,7 @@ func DeleteArticle(id int, username string) ErrorResponse {
 	db.Delete(&article)
 	db.Close()
 
-	return ErrorResponse{IsError: false}
+	return nil
 }
 
 // Utility functions //

--- a/db/article.go
+++ b/db/article.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	// "log"
+	"net/http"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
@@ -16,19 +16,26 @@ type Article struct {
 }
 
 // Get all data
-func GetArticles(username string) []Article {
-	db := gormConnect()
+func GetArticles(username string) ([]Article, ErrorResponse) {
+	var articles []Article
+
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return articles, errResp
+	}
 
 	defer db.Close()
-	var articles []Article
 	// Get all article data by specifying empty condition as the Find argument
 	db.Order("created_at desc").Where("Username = ?", username).Find(&articles)
-	return articles
+	return articles, ErrorResponse{IsError: false}
 }
 
 // Insert data
-func PostArticle(article Article) {
-	db := gormConnect()
+func PostArticle(article Article) ErrorResponse {
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return errResp
+	}
 
 	defer db.Close()
 	db.Create(&Article{
@@ -37,11 +44,16 @@ func PostArticle(article Article) {
 		Username: article.Username,
 		Tags:     article.Tags,
 	})
+
+	return ErrorResponse{IsError: false}
 }
 
 // Update DB
-func UpdateArticle(articleID int, updateArticle Article) string {
-	db := gormConnect()
+func UpdateArticle(articleID int, updateArticle Article) ErrorResponse {
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return errResp
+	}
 
 	// Delete old tags associated to this article
 	var tag Tag
@@ -51,28 +63,47 @@ func UpdateArticle(articleID int, updateArticle Article) string {
 	var article Article
 	db.First(&article, articleID)
 	if !isUserMatched(article.Username, updateArticle.Username) {
-		return "User is not matched"
+		return ErrorResponse{
+			IsError: true,
+			Status:  http.StatusBadRequest,
+			Message: "User is not matched",
+		}
 	}
 
 	updateArticleContents(&article, updateArticle)
 	db.Save(&article)
 	db.Close()
-	return ""
+
+	return ErrorResponse{IsError: false}
 }
 
 // Delete a article
-func DeleteArticle(id int, username string) string {
-	db := gormConnect()
+func DeleteArticle(id int, username string) ErrorResponse {
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return errResp
+	}
+
 	var article Article
 	if err := db.First(&article, id).Error; err != nil {
-		return "The article is not existed."
+		return ErrorResponse{
+			IsError: true,
+			Status:  http.StatusBadRequest,
+			Message: "The article is not existed.",
+		}
 	}
 	if !isUserMatched(article.Username, username) {
-		return "User is not matched"
+		return ErrorResponse{
+			IsError: true,
+			Status:  http.StatusBadRequest,
+			Message: "User is not matched",
+		}
 	}
+
 	db.Delete(&article)
 	db.Close()
-	return ""
+
+	return ErrorResponse{IsError: false}
 }
 
 // Utility functions //

--- a/db/article.go
+++ b/db/article.go
@@ -40,27 +40,28 @@ func PostArticle(article Article) {
 }
 
 // Update DB
-func UpdateArticle(articleID int, updateArticle Article) interface{} {
+func UpdateArticle(articleID int, updateArticle Article) string {
 	db := gormConnect()
 
 	// Delete old tags associated to this article
 	var tag Tag
 	db.Where("article_id = ?", articleID).Delete(&tag)
 
-	// Update article
+	// Check user is compatible
 	var article Article
 	db.First(&article, articleID)
-	if err := updateArticleContents(&article, updateArticle); err != nil {
-		return err
+	if !isUserMatched(article.Username, updateArticle.Username) {
+		return "User is not matched"
 	}
-	db.Save(&article)
 
+	updateArticleContents(&article, updateArticle)
+	db.Save(&article)
 	db.Close()
-	return nil
+	return ""
 }
 
 // Delete a article
-func DeleteArticle(id int, username string) interface{} {
+func DeleteArticle(id int, username string) string {
 	db := gormConnect()
 	var article Article
 	if err := db.First(&article, id).Error; err != nil {
@@ -71,15 +72,12 @@ func DeleteArticle(id int, username string) interface{} {
 	}
 	db.Delete(&article)
 	db.Close()
-	return nil
+	return ""
 }
 
 // Utility functions //
 
 func updateArticleContents(currentArticle *Article, newArticle Article) interface{} {
-	if !isUserMatched(currentArticle.Username, newArticle.Username) {
-		return "User is not matched"
-	}
 	if newArticle.Title != "" {
 		currentArticle.Title = newArticle.Title
 	}

--- a/db/tag.go
+++ b/db/tag.go
@@ -22,7 +22,7 @@ func GetTags(username string) []Tag {
 }
 
 // Add tags to article
-func AddTag(tag Tag, username string) interface{} {
+func AddTag(tag Tag, username string) string {
 	db := gormConnect()
 
 	// Check the requested tag is already exists
@@ -38,5 +38,5 @@ func AddTag(tag Tag, username string) interface{} {
 		Name:      tag.Name,
 		ArticleID: tag.ArticleID,
 	})
-	return nil
+	return ""
 }

--- a/db/tag.go
+++ b/db/tag.go
@@ -3,6 +3,7 @@ package db
 import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
+	"net/http"
 )
 
 type Tag struct {
@@ -12,25 +13,36 @@ type Tag struct {
 }
 
 // Get all tags
-func GetTags(username string) []Tag {
-	db := gormConnect()
+func GetTags(username string) ([]Tag, ErrorResponse) {
+	var tags []Tag
+
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return tags, errResp
+	}
 
 	defer db.Close()
-	var tags []Tag
 	db.Table("tags").Select("tags.name").Joins("left join articles on tags.article_id = articles.id").Find(&tags)
-	return tags
+	return tags, ErrorResponse{IsError: false}
 }
 
 // Add tags to article
-func AddTag(tag Tag, username string) string {
-	db := gormConnect()
+func AddTag(tag Tag, username string) ErrorResponse {
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return errResp
+	}
 
 	// Check the requested tag is already exists
 	defer db.Close()
 	var count int
 	db.Table("tags").Joins("left join articles on tags.article_id = articles.id").Where("articles.username = ? AND articles.id = ? AND tags.name = ?", username, tag.ArticleID, tag.Name).Count(&count)
 	if count != 0 {
-		return "This article has already the requested tag. Can't give same tags to one article."
+		return ErrorResponse{
+			IsError: true,
+			Status:  http.StatusBadRequest,
+			Message: "This article has already the requested tag. Can't give same tags to one article.",
+		}
 	}
 
 	// Add a new tag
@@ -38,5 +50,5 @@ func AddTag(tag Tag, username string) string {
 		Name:      tag.Name,
 		ArticleID: tag.ArticleID,
 	})
-	return ""
+	return ErrorResponse{IsError: false}
 }

--- a/db/tag.go
+++ b/db/tag.go
@@ -22,7 +22,7 @@ func GetTags(username string) ([]Tag, ErrorResponse) {
 	}
 
 	defer db.Close()
-	db.Table("tags").Select("tags.name").Joins("left join articles on tags.article_id = articles.id").Find(&tags)
+	db.Table("tags").Select("tags.*").Joins("left join articles on tags.article_id = articles.id").Find(&tags)
 	return tags, ErrorResponse{IsError: false}
 }
 

--- a/db/tag.go
+++ b/db/tag.go
@@ -13,24 +13,24 @@ type Tag struct {
 }
 
 // Get all tags
-func GetTags(username string) ([]Tag, ErrorResponse) {
+func GetTags(username string) ([]Tag, error) {
 	var tags []Tag
 
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return tags, errResp
+	db, err := gormConnect()
+	if err != nil {
+		return tags, err
 	}
 
 	defer db.Close()
 	db.Table("tags").Select("tags.*").Joins("left join articles on tags.article_id = articles.id").Find(&tags)
-	return tags, ErrorResponse{IsError: false}
+	return tags, nil
 }
 
 // Add tags to article
-func AddTag(tag Tag, username string) ErrorResponse {
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+func AddTag(tag Tag, username string) error {
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	// Check the requested tag is already exists
@@ -38,8 +38,7 @@ func AddTag(tag Tag, username string) ErrorResponse {
 	var count int
 	db.Table("tags").Joins("left join articles on tags.article_id = articles.id").Where("articles.username = ? AND articles.id = ? AND tags.name = ?", username, tag.ArticleID, tag.Name).Count(&count)
 	if count != 0 {
-		return ErrorResponse{
-			IsError: true,
+		return &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "This article has already the requested tag. Can't give same tags to one article.",
 		}
@@ -50,5 +49,5 @@ func AddTag(tag Tag, username string) ErrorResponse {
 		Name:      tag.Name,
 		ArticleID: tag.ArticleID,
 	})
-	return ErrorResponse{IsError: false}
+	return nil
 }

--- a/db/user.go
+++ b/db/user.go
@@ -20,7 +20,7 @@ type LoginUser struct {
 }
 
 // Register a new user
-func CreateUser(user User) interface{} {
+func CreateUser(user User) string {
 	passwordEncrypt, _ := crypto.PasswordEncrypt(user.Password)
 	db := gormConnect()
 	defer db.Close()
@@ -33,18 +33,18 @@ func CreateUser(user User) interface{} {
 			Email:    user.Email,
 		},
 	).Error; err != nil {
-		return err
+		return "Requested user is not compatible."
 	}
-	return nil
+	return ""
 }
 
 // Find a user
-func GetUser(username string) (User, error) {
+func GetUser(username string) (User, string) {
 	db := gormConnect()
 	var user User
 	if err := db.First(&user, "username = ?", username).Error; err != nil {
-		return user, err
+		return user, "Requested user does not exists."
 	}
 	db.Close()
-	return user, nil
+	return user, ""
 }

--- a/db/user.go
+++ b/db/user.go
@@ -15,12 +15,6 @@ type User struct {
 	Email    string `json:"email" binding:"required"`
 }
 
-type LoginUser struct {
-	gorm.Model
-	Username string `json:"username" binding:"required" gorm:"unique;not null"`
-	Password string `json:"password" binding:"required"`
-}
-
 // Register a new user
 func CreateUser(user User) ErrorResponse {
 	passwordEncrypt, _ := crypto.PasswordEncrypt(user.Password)

--- a/db/user.go
+++ b/db/user.go
@@ -16,11 +16,11 @@ type User struct {
 }
 
 // Register a new user
-func CreateUser(user User) ErrorResponse {
+func CreateUser(user User) error {
 	passwordEncrypt, _ := crypto.PasswordEncrypt(user.Password)
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	defer db.Close()
@@ -33,31 +33,29 @@ func CreateUser(user User) ErrorResponse {
 			Email:    user.Email,
 		},
 	).Error; err != nil {
-		return ErrorResponse{
-			IsError: true,
+		return &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "Requested user is not compatible.",
 		}
 	}
-	return ErrorResponse{IsError: false}
+	return nil
 }
 
 // Find a user
-func GetUser(username string) (User, ErrorResponse) {
+func GetUser(username string) (User, error) {
 	var user User
 
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return user, errResp
+	db, err := gormConnect()
+	if err != nil {
+		return user, err
 	}
 
 	if err := db.First(&user, "username = ?", username).Error; err != nil {
-		return user, ErrorResponse{
-			IsError: true,
+		return user, &ErrorResponse{
 			Status:  http.StatusBadRequest,
 			Message: "Requested user does not exists.",
 		}
 	}
 	db.Close()
-	return user, ErrorResponse{IsError: false}
+	return user, nil
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -1,13 +1,20 @@
 package db
 
 import (
+	"net/http"
 	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
 )
 
-func gormConnect() *gorm.DB {
+type ErrorResponse struct {
+	IsError bool
+	Status  int
+	Message string
+}
+
+func gormConnect() (*gorm.DB, ErrorResponse) {
 	DBMS := os.Getenv("SASG_DBMS")
 	USER := os.Getenv("SASG_USER")
 	PASS := os.Getenv("SASG_PASS")
@@ -17,18 +24,27 @@ func gormConnect() *gorm.DB {
 
 	db, err := gorm.Open(DBMS, CONNECT)
 	if err != nil {
-		panic(err.Error())
+		return nil,
+			ErrorResponse{
+				IsError: true,
+				Status:  http.StatusInternalServerError,
+				Message: "Cannot access to database. " + err.Error(),
+			}
 	}
-
-	return db
+	return db, ErrorResponse{IsError: false}
 }
 
 // Initialize DB
-func Init() {
-	db := gormConnect()
+func Init() ErrorResponse {
+	db, errResp := gormConnect()
+	if errResp.IsError {
+		return errResp
+	}
 
 	defer db.Close()
 	db.AutoMigrate(&Article{})
 	db.AutoMigrate(&Tag{})
 	db.AutoMigrate(&User{})
+
+	return ErrorResponse{IsError: false}
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -9,12 +9,15 @@ import (
 )
 
 type ErrorResponse struct {
-	IsError bool
 	Status  int
 	Message string
 }
 
-func gormConnect() (*gorm.DB, ErrorResponse) {
+func (e *ErrorResponse) Error() string {
+	return e.Message
+}
+
+func gormConnect() (*gorm.DB, error) {
 	DBMS := os.Getenv("SASG_DBMS")
 	USER := os.Getenv("SASG_USER")
 	PASS := os.Getenv("SASG_PASS")
@@ -25,20 +28,19 @@ func gormConnect() (*gorm.DB, ErrorResponse) {
 	db, err := gorm.Open(DBMS, CONNECT)
 	if err != nil {
 		return nil,
-			ErrorResponse{
-				IsError: true,
+			&ErrorResponse{
 				Status:  http.StatusInternalServerError,
 				Message: "Cannot access to database. " + err.Error(),
 			}
 	}
-	return db, ErrorResponse{IsError: false}
+	return db, nil
 }
 
 // Initialize DB
-func Init() ErrorResponse {
-	db, errResp := gormConnect()
-	if errResp.IsError {
-		return errResp
+func Init() error {
+	db, err := gormConnect()
+	if err != nil {
+		return err
 	}
 
 	defer db.Close()
@@ -46,5 +48,5 @@ func Init() ErrorResponse {
 	db.AutoMigrate(&Tag{})
 	db.AutoMigrate(&User{})
 
-	return ErrorResponse{IsError: false}
+	return nil
 }

--- a/handler/article.go
+++ b/handler/article.go
@@ -12,9 +12,14 @@ import (
 func GetArticles() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		username := c.Param("username")
-		articles, errResp := db.GetArticles(username)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		articles, err := db.GetArticles(username)
+		if err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 		c.JSON(http.StatusOK, gin.H{"articles": articles})
 	}
@@ -31,9 +36,13 @@ func PostArticle() gin.HandlerFunc {
 			BadRequestError(c, "Requested article is an invalid format")
 		}
 
-		errResp := db.PostArticle(article)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		if err := db.PostArticle(article); err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 		c.JSON(http.StatusOK, article)
 	}
@@ -57,9 +66,13 @@ func UpdateArticle() gin.HandlerFunc {
 		}
 
 		// Update article contents
-		errResp := db.UpdateArticle(articleID, article)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		if err := db.UpdateArticle(articleID, article); err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 
 		c.JSON(http.StatusOK, article)
@@ -79,9 +92,13 @@ func DeleteArticle() gin.HandlerFunc {
 		}
 
 		// Delete article
-		errResp := db.DeleteArticle(articleID, username)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		if err = db.DeleteArticle(articleID, username); err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 
 		c.JSON(http.StatusOK, gin.H{"username": username, "articleID": articleID})

--- a/handler/article.go
+++ b/handler/article.go
@@ -12,7 +12,10 @@ import (
 func GetArticles() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		username := c.Param("username")
-		articles := db.GetArticles(username)
+		articles, errResp := db.GetArticles(username)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
+		}
 		c.JSON(http.StatusOK, gin.H{"articles": articles})
 	}
 }
@@ -28,7 +31,10 @@ func PostArticle() gin.HandlerFunc {
 			BadRequestError(c, "Requested article is an invalid format")
 		}
 
-		db.PostArticle(article)
+		errResp := db.PostArticle(article)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
+		}
 		c.JSON(http.StatusOK, article)
 	}
 }
@@ -49,8 +55,11 @@ func UpdateArticle() gin.HandlerFunc {
 		if err := c.Bind(&article); err != nil {
 			BadRequestError(c, "Requested article is an invalid format")
 		}
-		if errmsg := db.UpdateArticle(articleID, article); errmsg != "" {
-			BadRequestError(c, errmsg)
+
+		// Update article contents
+		errResp := db.UpdateArticle(articleID, article)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
 		}
 
 		c.JSON(http.StatusOK, article)
@@ -70,8 +79,9 @@ func DeleteArticle() gin.HandlerFunc {
 		}
 
 		// Delete article
-		if errmsg := db.DeleteArticle(articleID, username); errmsg != "" {
-			BadRequestError(c, errmsg)
+		errResp := db.DeleteArticle(articleID, username)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
 		}
 
 		c.JSON(http.StatusOK, gin.H{"username": username, "articleID": articleID})

--- a/handler/article.go
+++ b/handler/article.go
@@ -20,6 +20,7 @@ func GetArticles() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 		c.JSON(http.StatusOK, gin.H{"articles": articles})
 	}
@@ -34,6 +35,7 @@ func PostArticle() gin.HandlerFunc {
 		// Validation
 		if err := c.Bind(&article); err != nil {
 			BadRequestError(c, "Requested article is an invalid format")
+			return
 		}
 
 		if err := db.PostArticle(article); err != nil {
@@ -43,6 +45,7 @@ func PostArticle() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 		c.JSON(http.StatusOK, article)
 	}
@@ -58,11 +61,13 @@ func UpdateArticle() gin.HandlerFunc {
 		articleID, err := strconv.Atoi(articleIDStr)
 		if err != nil {
 			NotFoundError(c, "articleID is invalid type. It should be uint.")
+			return
 		}
 
 		article := db.Article{Username: username}
 		if err := c.Bind(&article); err != nil {
 			BadRequestError(c, "Requested article is an invalid format")
+			return
 		}
 
 		// Update article contents
@@ -73,6 +78,7 @@ func UpdateArticle() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 
 		c.JSON(http.StatusOK, article)
@@ -89,6 +95,7 @@ func DeleteArticle() gin.HandlerFunc {
 		articleID, err := strconv.Atoi(articleIDStr)
 		if err != nil {
 			NotFoundError(c, "articleID is invalid type. It should be uint.")
+			return
 		}
 
 		// Delete article
@@ -99,6 +106,7 @@ func DeleteArticle() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{"username": username, "articleID": articleID})

--- a/handler/auth.go
+++ b/handler/auth.go
@@ -21,6 +21,7 @@ func VerifyToken() gin.HandlerFunc {
 		)
 		if err != nil {
 			UnauthorizedError(c, "Invalid token. "+err.Error())
+			return
 		}
 	}
 }

--- a/handler/auth.go
+++ b/handler/auth.go
@@ -1,13 +1,12 @@
-package auth
+package handler
 
 import (
-	"github.com/gin-gonic/gin"
-	"net/http"
 	"os"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	jwtrequest "github.com/dgrijalva/jwt-go/request"
+	"github.com/gin-gonic/gin"
 	"github.com/tanimutomo/simple-api-server-go/db"
 )
 
@@ -21,8 +20,7 @@ func VerifyToken() gin.HandlerFunc {
 			},
 		)
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"Error": "Unauthorized"})
-			c.Abort()
+			UnauthorizedError(c, "Invalid token. "+err.Error())
 		}
 	}
 }

--- a/handler/error.go
+++ b/handler/error.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func BadRequestError(c *gin.Context, message string) {
+	ErrorResponse(c, http.StatusBadRequest, message)
+}
+
+func NotFoundError(c *gin.Context, message string) {
+	ErrorResponse(c, http.StatusNotFound, message)
+}
+
+func UnauthorizedError(c *gin.Context, message string) {
+	ErrorResponse(c, http.StatusUnauthorized, message)
+}
+
+func ErrorResponse(c *gin.Context, status int, message string) {
+	c.JSON(status, gin.H{"message": message})
+	c.Abort()
+}

--- a/handler/error.go
+++ b/handler/error.go
@@ -18,6 +18,10 @@ func UnauthorizedError(c *gin.Context, message string) {
 	SendErrorResponse(c, http.StatusUnauthorized, message)
 }
 
+func InternalServerError(c *gin.Context, message string) {
+	SendErrorResponse(c, http.StatusInternalServerError, message)
+}
+
 func SendErrorResponse(c *gin.Context, status int, message string) {
 	c.JSON(status, gin.H{"message": message})
 	c.Abort()

--- a/handler/error.go
+++ b/handler/error.go
@@ -7,18 +7,18 @@ import (
 )
 
 func BadRequestError(c *gin.Context, message string) {
-	ErrorResponse(c, http.StatusBadRequest, message)
+	SendErrorResponse(c, http.StatusBadRequest, message)
 }
 
 func NotFoundError(c *gin.Context, message string) {
-	ErrorResponse(c, http.StatusNotFound, message)
+	SendErrorResponse(c, http.StatusNotFound, message)
 }
 
 func UnauthorizedError(c *gin.Context, message string) {
-	ErrorResponse(c, http.StatusUnauthorized, message)
+	SendErrorResponse(c, http.StatusUnauthorized, message)
 }
 
-func ErrorResponse(c *gin.Context, status int, message string) {
+func SendErrorResponse(c *gin.Context, status int, message string) {
 	c.JSON(status, gin.H{"message": message})
 	c.Abort()
 }

--- a/handler/tag.go
+++ b/handler/tag.go
@@ -23,24 +23,23 @@ func AddTag() gin.HandlerFunc {
 		username := c.Param("username")
 		articleIDStr := c.Param("articleID")
 
+		// Check articleID compatibility
 		articleID, err := strconv.ParseUint(articleIDStr, 10, 32)
 		if err != nil {
-			panic(err)
+			NotFoundError(c, "articleID is invalid type. It should be uint.")
 		}
 		tag := db.Tag{ArticleID: articleID}
 
 		// Validation
 		if err := c.Bind(&tag); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"message": err})
-			c.Abort()
+			BadRequestError(c, "Requested tag is an invalid format")
 		}
 
 		// Insert a new tag to DB
-		if err := db.AddTag(tag, username); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"message": err})
-			c.Abort()
+		if errmsg := db.AddTag(tag, username); errmsg != "" {
+			BadRequestError(c, errmsg)
 		}
 
-		c.JSON(http.StatusOK, gin.H{"message": "Success to add a new tag"})
+		c.JSON(http.StatusOK, tag)
 	}
 }

--- a/handler/tag.go
+++ b/handler/tag.go
@@ -12,7 +12,10 @@ import (
 func GetTags() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		username := c.Param("username")
-		tags := db.GetTags(username)
+		tags, errResp := db.GetTags(username)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
+		}
 		c.JSON(http.StatusOK, gin.H{"tags": tags})
 	}
 }
@@ -36,8 +39,9 @@ func AddTag() gin.HandlerFunc {
 		}
 
 		// Insert a new tag to DB
-		if errmsg := db.AddTag(tag, username); errmsg != "" {
-			BadRequestError(c, errmsg)
+		errResp := db.AddTag(tag, username)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
 		}
 
 		c.JSON(http.StatusOK, tag)

--- a/handler/tag.go
+++ b/handler/tag.go
@@ -21,6 +21,7 @@ func GetTags() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 		c.JSON(http.StatusOK, gin.H{"tags": tags})
 	}
@@ -36,12 +37,14 @@ func AddTag() gin.HandlerFunc {
 		articleID, err := strconv.ParseUint(articleIDStr, 10, 32)
 		if err != nil {
 			NotFoundError(c, "articleID is invalid type. It should be uint.")
+			return
 		}
 		tag := db.Tag{ArticleID: articleID}
 
 		// Validation
 		if err := c.Bind(&tag); err != nil {
 			BadRequestError(c, "Requested tag is an invalid format")
+			return
 		}
 
 		// Insert a new tag to DB
@@ -52,6 +55,7 @@ func AddTag() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 
 		c.JSON(http.StatusOK, tag)

--- a/handler/tag.go
+++ b/handler/tag.go
@@ -12,6 +12,7 @@ import (
 func GetTags() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		username := c.Param("username")
+
 		tags, errResp := db.GetTags(username)
 		if errResp.IsError {
 			SendErrorResponse(c, errResp.Status, errResp.Message)

--- a/handler/tag.go
+++ b/handler/tag.go
@@ -13,9 +13,14 @@ func GetTags() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		username := c.Param("username")
 
-		tags, errResp := db.GetTags(username)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		tags, err := db.GetTags(username)
+		if err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 		c.JSON(http.StatusOK, gin.H{"tags": tags})
 	}
@@ -40,9 +45,13 @@ func AddTag() gin.HandlerFunc {
 		}
 
 		// Insert a new tag to DB
-		errResp := db.AddTag(tag, username)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		if err := db.AddTag(tag, username); err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 
 		c.JSON(http.StatusOK, tag)

--- a/handler/user.go
+++ b/handler/user.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -23,9 +24,13 @@ func Signup() gin.HandlerFunc {
 		}
 
 		// Check same username exists
-		errResp := db.CreateUser(user)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		if err := db.CreateUser(user); err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 
 		c.JSON(http.StatusOK, user)
@@ -43,9 +48,14 @@ func Login() gin.HandlerFunc {
 		}
 
 		// Check whether user is exists
-		dbUser, errResp := db.GetUser(loginUser.Username)
-		if errResp.IsError {
-			SendErrorResponse(c, errResp.Status, errResp.Message)
+		dbUser, err := db.GetUser(loginUser.Username)
+		if err != nil {
+			switch e := err.(type) {
+			case *db.ErrorResponse:
+				SendErrorResponse(c, e.Status, e.Message)
+			default:
+				InternalServerError(c, "Unknown Type Error")
+			}
 		}
 
 		// Compare sent password to db password

--- a/handler/user.go
+++ b/handler/user.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,6 +20,7 @@ func Signup() gin.HandlerFunc {
 		// Validation
 		if err := c.Bind(&user); err != nil {
 			BadRequestError(c, "Requested user is an invalid format")
+			return
 		}
 
 		// Check same username exists
@@ -31,6 +31,7 @@ func Signup() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 
 		c.JSON(http.StatusOK, user)
@@ -56,6 +57,7 @@ func Login() gin.HandlerFunc {
 			default:
 				InternalServerError(c, "Unknown Type Error")
 			}
+			return
 		}
 
 		// Compare sent password to db password
@@ -65,6 +67,7 @@ func Login() gin.HandlerFunc {
 			dbPassword, sentPassword,
 		); err != nil {
 			UnauthorizedError(c, "Invalid password")
+			return
 		}
 
 		tokenString := GetToken(dbUser)

--- a/handler/user.go
+++ b/handler/user.go
@@ -58,6 +58,9 @@ func Login() gin.HandlerFunc {
 		}
 
 		tokenString := GetToken(dbUser)
-		c.JSON(http.StatusOK, gin.H{"user": dbUser, "token": tokenString})
+		c.JSON(http.StatusOK, gin.H{
+			"username": loginUser.Username,
+			"token":    tokenString,
+		})
 	}
 }

--- a/handler/user.go
+++ b/handler/user.go
@@ -8,6 +8,11 @@ import (
 	"github.com/tanimutomo/simple-api-server-go/db"
 )
 
+type LoginRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
 // Signup
 func Signup() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -30,7 +35,8 @@ func Signup() gin.HandlerFunc {
 // Login
 func Login() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var loginUser db.LoginUser
+		var loginUser LoginRequest
+
 		// Validate request
 		if err := c.Bind(&loginUser); err != nil {
 			BadRequestError(c, "Requested login user is an invalid format")

--- a/handler/user.go
+++ b/handler/user.go
@@ -18,8 +18,9 @@ func Signup() gin.HandlerFunc {
 		}
 
 		// Check same username exists
-		if errmsg := db.CreateUser(user); errmsg != "" {
-			BadRequestError(c, errmsg)
+		errResp := db.CreateUser(user)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
 		}
 
 		c.JSON(http.StatusOK, user)
@@ -36,9 +37,9 @@ func Login() gin.HandlerFunc {
 		}
 
 		// Check whether user is exists
-		dbUser, errmsg := db.GetUser(loginUser.Username)
-		if errmsg != "" {
-			BadRequestError(c, errmsg)
+		dbUser, errResp := db.GetUser(loginUser.Username)
+		if errResp.IsError {
+			SendErrorResponse(c, errResp.Status, errResp.Message)
 		}
 
 		// Compare sent password to db password

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	_ "github.com/joho/godotenv/autoload"
-	"github.com/tanimutomo/simple-api-server-go/auth"
 	"github.com/tanimutomo/simple-api-server-go/db"
 	"github.com/tanimutomo/simple-api-server-go/handler"
 )
@@ -26,7 +25,7 @@ func main() {
 	// Login -> Get token
 	r.POST("/login", handler.Login())
 
-	users := r.Group("/users", auth.VerifyToken())
+	users := r.Group("/users", handler.VerifyToken())
 	{
 		// Get a list of articles
 		users.GET("/:username/articles", handler.GetArticles())


### PR DESCRIPTION
### 主な変更点
- `ErrorResponse` struct によって，dbとhandler のpkg 間のやりとりをすることにした
- `handler/error.go`で，error系のresponse方法を定義して，reponseの一貫性を担保 #3 
- 200系のresponseの時だけ，request bodyをresponse bodyに含めるようにした #5 
- LoginRequst 型をhandler側で定義 #4 

#### `ErrorResponse` の導入理由
- db pkgはdb周りの処理だけ（dbの検索等）に集中させる (http responseやginを介入させたくない)
- handler pkgはrequestのresponse処理だけをさせる (dbには介入しない)

ということを実現したい．

しかし，dbで出るエラーによって返すresponseのstatusやmessageがかわるので，db側でエラーのステータスと内容くらいは決定して，handler側に渡す必要がある

となった結果，`ErrorResponse` 型を導入するに至った
